### PR TITLE
Force 2.0.0 dependencies for ApplicationInsights

### DIFF
--- a/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.csproj
+++ b/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.csproj
@@ -13,9 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="$(AppInsightsVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Proposal for Preview1:
Without this it is possible to publish an App that gets `Microsoft.Extensions.Configuration.Json 1.0.0` from `Microsoft.Applicationinsights.AspNetCore 2.1.0` which has a bug where if optional is set for `AddJson` and the directory doesn't exist it will throw. So customers Apps could fail to run if they enable AppInsights