### PR TITLE
Skip ApplicationInsightsLoggingTest.ScriptInjected

### DIFF
--- a/test/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.Tests/ApplicationInsightsLoggingTest.cs
+++ b/test/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.Tests/ApplicationInsightsLoggingTest.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,7 +19,7 @@ namespace ApplicationInsightsJavaScriptSnippetTest
         {
         }
 
-        [Theory]
+        [ConditionalTheory(Skip = "https://github.com/aspnet/AzureIntegration/issues/41")]
         [InlineData(ApplicationType.Portable)]
         [InlineData(ApplicationType.Standalone)]
         public async Task ScriptInjected(ApplicationType applicationType)


### PR DESCRIPTION
- Required to unblock Preview1 build
- Suspected fix is to react to https://github.com/aspnet/Hosting/commit/3936bf64f6edf8a1e3cca8f6e248f60c073b312d
- Unskip: https://github.com/aspnet/AzureIntegration/issues/41