### PR TITLE
Disable lightup logger if user adds AI logger

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0-preview1-*</AspNetCoreVersion>
     <AspNetIntegrationTestingVersion>0.4.0-*</AspNetIntegrationTestingVersion>
-    <AppInsightsVersion>2.1.0-beta2</AppInsightsVersion>
+    <AppInsightsVersion>2.1.0-beta3</AppInsightsVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <MoqVersion>4.7.1</MoqVersion>

--- a/sample/ApplicationInsightsHostingStartupSample/Startup.cs
+++ b/sample/ApplicationInsightsHostingStartupSample/Startup.cs
@@ -45,6 +45,7 @@ namespace IISSample
         {
             app.Map("/log", logApp => logApp.Run(async context =>
             {
+                var oldChannel = TelemetryConfiguration.Active.TelemetryChannel;
                 TelemetryConfiguration.Active.TelemetryChannel = new CurrentResponseTelemetryChannel(context.Response);
 
                 var systemLogger = loggerFactory.CreateLogger("System.Namespace");
@@ -67,7 +68,7 @@ namespace IISSample
                 specificLogger.LogInformation("Specific information log");
                 specificLogger.LogWarning("Specific warning log");
 
-                TelemetryConfiguration.Active.TelemetryChannel = null;
+                TelemetryConfiguration.Active.TelemetryChannel = oldChannel;
 
                 return Task.CompletedTask;
             }));
@@ -92,7 +93,10 @@ namespace IISSample
                 .UseConfiguration(config)
                 .ConfigureLogging<LoggerFactory>((context, factory) =>
                 {
+                    if (config["WIRE_LOGGING_CONFIGURATION"]?.ToLowerInvariant() != "false")
+                    {
                     factory.UseConfiguration(context.Configuration.GetSection("Logging"));
+                    }
                 })
                 .Build();
 

--- a/sample/ApplicationInsightsHostingStartupSample/Startup.cs
+++ b/sample/ApplicationInsightsHostingStartupSample/Startup.cs
@@ -24,19 +24,16 @@ namespace IISSample
 
         public void ConfigureJavaScript(IApplicationBuilder app, ILoggerFactory loggerFactory, IServiceProvider serviceProvider)
         {
-            loggerFactory.AddConsole(LogLevel.Debug);
             app.UseMvcWithDefaultRoute();
         }
 
         public void ConfigureDefaultLogging(IApplicationBuilder app, ILoggerFactory loggerFactory, IServiceProvider serviceProvider)
         {
-            loggerFactory.AddConsole(LogLevel.Debug);
             ConfigureLoggingMiddleware(app, loggerFactory);
         }
 
         public void ConfigureCustomLogging(IApplicationBuilder app, ILoggerFactory loggerFactory, IServiceProvider serviceProvider)
         {
-            loggerFactory.AddConsole(LogLevel.Debug);
             loggerFactory.AddApplicationInsights(serviceProvider, (s, level) => s.Contains("o"));
             ConfigureLoggingMiddleware(app, loggerFactory);
         }
@@ -84,7 +81,7 @@ namespace IISSample
             var host = new WebHostBuilder()
                 .ConfigureLogging((hostingContext, factory) =>
                 {
-                    if (config["WIRE_LOGGING_CONFIGURATION"]?.ToLowerInvariant() != "false")
+                    if (hostingContext.Configuration["WIRE_LOGGING_CONFIGURATION"]?.ToLowerInvariant() != "false")
                     {
                         factory.UseConfiguration(hostingContext.Configuration.GetSection("Logging"));
                     }

--- a/sample/ApplicationInsightsHostingStartupSample/Startup.cs
+++ b/sample/ApplicationInsightsHostingStartupSample/Startup.cs
@@ -43,7 +43,7 @@ namespace IISSample
 
         private static void ConfigureLoggingMiddleware(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
-            app.Map("/log", logApp => logApp.Run(async context =>
+            app.Map("/log", logApp => logApp.Run(context =>
             {
                 var oldChannel = TelemetryConfiguration.Active.TelemetryChannel;
                 TelemetryConfiguration.Active.TelemetryChannel = new CurrentResponseTelemetryChannel(context.Response);
@@ -72,7 +72,7 @@ namespace IISSample
 
                 return Task.CompletedTask;
             }));
-                }
+        }
 
         public static void Main(string[] args)
         {
@@ -84,20 +84,16 @@ namespace IISSample
             var host = new WebHostBuilder()
                 .ConfigureLogging((hostingContext, factory) =>
                 {
-                    factory.UseConfiguration(hostingContext.Configuration.GetSection("Logging"))
-                           .AddConsole();
+                    if (config["WIRE_LOGGING_CONFIGURATION"]?.ToLowerInvariant() != "false")
+                    {
+                        factory.UseConfiguration(hostingContext.Configuration.GetSection("Logging"));
+                    }
+                    factory.AddConsole();
                 })
                 .UseKestrel()
                 .UseStartup<Startup>()
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseConfiguration(config)
-                .ConfigureLogging<LoggerFactory>((context, factory) =>
-                {
-                    if (config["WIRE_LOGGING_CONFIGURATION"]?.ToLowerInvariant() != "false")
-                    {
-                    factory.UseConfiguration(context.Configuration.GetSection("Logging"));
-                    }
-                })
                 .Build();
 
             host.Run();

--- a/sample/ApplicationInsightsHostingStartupSample/Startup.cs
+++ b/sample/ApplicationInsightsHostingStartupSample/Startup.cs
@@ -22,12 +22,12 @@ namespace IISSample
             services.AddMvc();
         }
 
-        public void ConfigureJavaScript(IApplicationBuilder app, ILoggerFactory loggerFactory, IServiceProvider serviceProvider)
+        public void ConfigureJavaScript(IApplicationBuilder app)
         {
             app.UseMvcWithDefaultRoute();
         }
 
-        public void ConfigureDefaultLogging(IApplicationBuilder app, ILoggerFactory loggerFactory, IServiceProvider serviceProvider)
+        public void ConfigureDefaultLogging(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             ConfigureLoggingMiddleware(app, loggerFactory);
         }

--- a/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerConfiguration.cs
+++ b/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerConfiguration.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.ApplicationInsights.HostingStartup
             foreach (var pair in _defaultLoggingLevels)
             {
                 // Default is null
-                if (pair.Key == null || name.StartsWith((string) pair.Key))
+                if (pair.Key == null || name.StartsWith(pair.Key))
                 {
                     return level >= pair.Value;
                 }

--- a/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerConfiguration.cs
+++ b/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerConfiguration.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.ApplicationInsights.HostingStartup
+{
+    internal class ApplicationInsightsLoggerConfiguration
+    {
+        private const string ApplicationInsightsLoggerFactory = "Microsoft.ApplicationInsights.AspNetCore.Logging.ApplicationInsightsLoggerProvider";
+        private const string ApplicationInsightsLoggerLevelSection = "Logging:" + ApplicationInsightsLoggerFactory + ":LogLevel";
+        private const string ApplicationInsightsSettingsFile = "ApplicationInsights.settings.json";
+
+        private static readonly KeyValuePair<string, LogLevel>[] _defaultLoggingLevels = {
+            new KeyValuePair<string, LogLevel>("Microsoft", LogLevel.Warning),
+            new KeyValuePair<string, LogLevel>("System", LogLevel.Warning),
+            new KeyValuePair<string, LogLevel>(null, LogLevel.Information)
+        };
+
+        public static void ConfigureLogging(IConfigurationBuilder configurationBuilder)
+        {
+            // Skip adding default rules when debugger is attached
+            // we want to send all events to VS
+            if (!Debugger.IsAttached)
+            {
+                configurationBuilder.AddInMemoryCollection(GetDefaultLoggingSettings());
+            }
+
+            var home = Environment.GetEnvironmentVariable("HOME");
+            if (!string.IsNullOrEmpty(home))
+            {
+                var settingsFile = Path.Combine(home, "site", "diagnostics", ApplicationInsightsSettingsFile);
+                configurationBuilder.AddJsonFile(settingsFile, optional: true);
+            }
+        }
+
+        public static bool ApplyDefaultFilter(string name, LogLevel level)
+        {
+            foreach (var pair in _defaultLoggingLevels)
+            {
+                // Default is null
+                if (pair.Key == null || name.StartsWith((string) pair.Key))
+                {
+                    return level >= pair.Value;
+                }
+            }
+
+            return false;
+        }
+
+        public static bool HasLoggingConfigured(IConfiguration configuration)
+        {
+            return configuration?.GetSection(ApplicationInsightsLoggerLevelSection) != null;
+        }
+
+        private static KeyValuePair<string, string>[] GetDefaultLoggingSettings()
+        {
+            return _defaultLoggingLevels.Select(pair =>
+            {
+                var key = pair.Key ?? "Default";
+                var optionsKey = $"{ApplicationInsightsLoggerLevelSection}:{key}";
+                return new KeyValuePair<string, string>(optionsKey, pair.Value.ToString());
+            }).ToArray();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerConfiguration.cs
+++ b/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerConfiguration.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.ApplicationInsights.HostingStartup
             foreach (var pair in _defaultLoggingLevels)
             {
                 // Default is null
-                if (pair.Key == null || name.StartsWith(pair.Key))
+                if (pair.Key == null || name.StartsWith(pair.Key, StringComparison.Ordinal))
                 {
                     return level >= pair.Value;
                 }

--- a/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerConfiguration.cs
+++ b/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerConfiguration.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.ApplicationInsights.HostingStartup
             foreach (var pair in _defaultLoggingLevels)
             {
                 // Default is null
-                if (pair.Key == null || name.StartsWith(pair.Key))
+                if (pair.Key == null || name.StartsWith(pair.Key, StringComparison.OrdinalIgnoreCase))
                 {
                     return level >= pair.Value;
                 }

--- a/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerConfiguration.cs
+++ b/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerConfiguration.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.ApplicationInsights.HostingStartup
             foreach (var pair in _defaultLoggingLevels)
             {
                 // Default is null
-                if (pair.Key == null || name.StartsWith(pair.Key, StringComparison.OrdinalIgnoreCase))
+                if (pair.Key == null || name.StartsWith(pair.Key))
                 {
                     return level >= pair.Value;
                 }

--- a/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerStartupFilter.cs
+++ b/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerStartupFilter.cs
@@ -24,7 +24,8 @@ namespace Microsoft.AspNetCore.ApplicationInsights.HostingStartup
                 if (loggerFactory is LoggerFactory stronglyTypedLoggerFactory &&
                     ApplicationInsightsLoggerConfiguration.HasLoggingConfigured(stronglyTypedLoggerFactory.Configuration))
                 {
-                    // We detected that logger settings got to LoggerFactory confi
+                    // We detected that logger settings got to LoggerFactory configuration and
+                    // defaults would be applied
                     loggerFactory.AddApplicationInsights(
                         builder.ApplicationServices,
                         (s, level) => loggerEnabled,

--- a/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerStartupFilter.cs
+++ b/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsLoggerStartupFilter.cs
@@ -11,15 +11,14 @@ namespace Microsoft.AspNetCore.ApplicationInsights.HostingStartup
 {
     internal class ApplicationInsightsLoggerStartupFilter : IStartupFilter
     {
-        private readonly Func<string, LogLevel, bool> _noFilter = (s, level) => true;
-
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
         {
             return builder =>
             {
                 var loggerFactory = builder.ApplicationServices.GetService<ILoggerFactory>();
                 // We need to disable filtering on logger, filtering would be done by LoggerFactory
-                loggerFactory.AddApplicationInsights(builder.ApplicationServices, _noFilter);
+                var loggerEnabled = true;
+                loggerFactory.AddApplicationInsights(builder.ApplicationServices, (s, level) => loggerEnabled, () => loggerEnabled = false);
                 next(builder);
             };
         }

--- a/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsStartupLoader.cs
+++ b/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/ApplicationInsightsStartupLoader.cs
@@ -1,14 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 [assembly: HostingStartup(typeof(Microsoft.AspNetCore.ApplicationInsights.HostingStartup.ApplicationInsightsHostingStartup))]
@@ -23,14 +17,6 @@ namespace Microsoft.AspNetCore.ApplicationInsights.HostingStartup
     /// </summary>
     public class ApplicationInsightsHostingStartup : IHostingStartup
     {
-        private const string ApplicationInsightsLoggerFactory = "Microsoft.ApplicationInsights.AspNetCore.Logging.ApplicationInsightsLoggerProvider";
-        private const string ApplicationInsightsSettingsFile = "ApplicationInsights.settings.json";
-
-        private static readonly KeyValuePair<string, string>[] _defaultLoggingLevels = {
-            new KeyValuePair<string, string>("Microsoft", "Warning"),
-            new KeyValuePair<string, string>("System", "Warning"),
-            new KeyValuePair<string, string>("Default", "Information")
-        };
 
         /// <summary>
         /// Calls UseApplicationInsights
@@ -38,37 +24,12 @@ namespace Microsoft.AspNetCore.ApplicationInsights.HostingStartup
         /// <param name="builder"></param>
         public void Configure(IWebHostBuilder builder)
         {
-            builder.ConfigureAppConfiguration((context, configurationBuilder) => ConfigureLogging(configurationBuilder));
+            builder.ConfigureAppConfiguration((context, configurationBuilder) => ApplicationInsightsLoggerConfiguration.ConfigureLogging(configurationBuilder));
             builder.UseApplicationInsights();
 
             builder.ConfigureServices(InitializeServices);
         }
 
-        private static void ConfigureLogging(IConfigurationBuilder configurationBuilder)
-        {
-            // Skip adding default rules when debugger is attached
-            // we want to send all events to VS
-            if (!Debugger.IsAttached)
-            {
-                configurationBuilder.AddInMemoryCollection(GetDefaultLoggingSettings());
-            }
-
-            var home = Environment.GetEnvironmentVariable("HOME");
-            if (!string.IsNullOrEmpty(home))
-            {
-                var settingsFile = Path.Combine(home, "site", "diagnostics", ApplicationInsightsSettingsFile);
-                configurationBuilder.AddJsonFile(settingsFile, optional: true);
-            }
-        }
-
-        private static KeyValuePair<string, string>[] GetDefaultLoggingSettings()
-        {
-            return _defaultLoggingLevels.Select(pair =>
-                {
-                    var key = $"Logging:{ApplicationInsightsLoggerFactory}:LogLevel:{pair.Key}";
-                    return new KeyValuePair<string, string>(key, pair.Value);
-                }).ToArray();
-        }
 
         /// <summary>
         /// Adds the Javascript <see cref="TagHelperComponent"/> to the <see cref="IServiceCollection"/>.

--- a/src/Microsoft.AspNetCore.AzureAppServicesIntegration/AppServicesWebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.AzureAppServicesIntegration/AppServicesWebHostBuilderExtensions.cs
@@ -19,9 +19,9 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 throw new ArgumentNullException(nameof(hostBuilder));
             }
-
+#pragma warning disable 618
             hostBuilder.ConfigureLogging(loggerFactory => loggerFactory.AddAzureWebAppDiagnostics());
-
+#pragma warning restore 618
             return hostBuilder;
         }
     }

--- a/test/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.Tests/ApplicationInsightsJavaScriptSnippetTest.cs
+++ b/test/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.Tests/ApplicationInsightsJavaScriptSnippetTest.cs
@@ -41,6 +41,7 @@ namespace ApplicationInsightsJavaScriptSnippetTest
                     TargetFramework = "netcoreapp2.0",
                     Configuration = GetCurrentBuildConfiguration(),
                     ApplicationType = applicationType,
+                    EnvironmentName = "JavaScript",
                     EnvironmentVariables =
                     {
                         new KeyValuePair<string, string>(

--- a/test/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.Tests/ApplicationInsightsLoggingTest.cs
+++ b/test/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.Tests/ApplicationInsightsLoggingTest.cs
@@ -22,8 +22,17 @@ namespace ApplicationInsightsJavaScriptSnippetTest
         [InlineData(ApplicationType.Standalone)]
         public async Task DefaultAILogFiltersApplied(ApplicationType applicationType)
         {
-            var responseText = await RunRequest(applicationType, "DefaultLogging");
+            var responseText = await RunRequest(applicationType, "DefaultLogging", true);
             AssertDefaultLogs(responseText);
+        }
+
+        [Theory]
+        [InlineData(ApplicationType.Portable)]
+        [InlineData(ApplicationType.Standalone)]
+        public async Task DefaultAILogFiltersAppliedWithoutConfiguration(ApplicationType applicationType)
+        {
+            var responseText = await RunRequest(applicationType, "DefaultLogging", false);
+            AssertDefaultNoConfigurationLogs(responseText);
         }
 
         [Theory]
@@ -31,7 +40,7 @@ namespace ApplicationInsightsJavaScriptSnippetTest
         [InlineData(ApplicationType.Standalone)]
         public async Task CustomAILogFiltersApplied(ApplicationType applicationType)
         {
-            var responseText = await RunRequest(applicationType, "CustomLogging");
+            var responseText = await RunRequest(applicationType, "CustomLogging", true);
             AssertCustomLogs(responseText);
         }
 
@@ -66,6 +75,37 @@ namespace ApplicationInsightsJavaScriptSnippetTest
             Assert.Contains("Specific trace log", responseText);
         }
 
+        private static void AssertDefaultNoConfigurationLogs(string responseText)
+        {
+            // Enabled by default
+            Assert.Contains("System warning log", responseText);
+            // Disabled by default
+            Assert.DoesNotContain("System information log", responseText);
+            // Disabled by default
+            Assert.DoesNotContain("System trace log", responseText);
+
+            // Enabled by default
+            Assert.Contains("Microsoft warning log", responseText);
+            // Disabled by default
+            Assert.DoesNotContain("Microsoft information log", responseText);
+            // Disabled by default
+            Assert.DoesNotContain("Microsoft trace log", responseText);
+
+            // Enabled by default
+            Assert.Contains("Custom warning log", responseText);
+            // Enabled by default
+            Assert.Contains("Custom information log", responseText);
+            // Disabled by default
+            Assert.DoesNotContain("Custom trace log", responseText);
+
+            // Enabled by default
+            Assert.Contains("Specific warning log", responseText);
+            // Enabled by default
+            Assert.Contains("Specific information log", responseText);
+            // Disabled by default
+            Assert.DoesNotContain("Specific trace log", responseText);
+        }
+
         private static void AssertCustomLogs(string responseText)
         {
             // Custom logger allows only namespaces with 'o' in the name
@@ -90,7 +130,7 @@ namespace ApplicationInsightsJavaScriptSnippetTest
             Assert.DoesNotContain("Specific trace log", responseText);
         }
 
-        private async Task<string> RunRequest(ApplicationType applicationType, string environment)
+        private async Task<string> RunRequest(ApplicationType applicationType, string environment, bool wireConfiguration)
         {
             string responseText;
             var testName = $"ApplicationInsightsLoggingTest_{applicationType}";
@@ -114,6 +154,9 @@ namespace ApplicationInsightsJavaScriptSnippetTest
                         new KeyValuePair<string, string>(
                             "HOME",
                             Path.Combine(GetApplicationPath(), "home")),
+                        new KeyValuePair<string, string>(
+                            "ASPNETCORE_WIRE_LOGGING_CONFIGURATION",
+                            wireConfiguration.ToString()),
                     },
                 };
 


### PR DESCRIPTION
Also prevents a situation when default `IConfiguration` is not wired to `LogginFactory` and lightup logger is sending all events to AI. 