### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -4,14 +4,7 @@
             "AdxVerificationCompositeRule"
         ],
         "packages": {
-          "Microsoft.AspNetCore.AzureAppServicesIntegration": { },
-          "Microsoft.AspNetCore.AzureAppServices.SiteExtension": {
-            "Exclusions": {
-              "THIRDPARTY_DEPENDENCY_NOT_REGISTERED": {
-                "Microsoft.AspNetCore.AzureAppServices.SiteExtension; .NETFramework,Version=v4.5.1": "Microsoft.Web.Xdt.Extensions is locally developed and bundled into this package."
-              }
-            }
-          }
+          "Microsoft.AspNetCore.AzureAppServicesIntegration": { }
         }
     },
     "Default": { // Rules to run for packages not listed in any other set.

--- a/build/common.props
+++ b/build/common.props
@@ -16,8 +16,4 @@
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework' AND '$(OutputType)'=='library'">
-    <PackageReference Include="NETStandard.Library" Version="$(BundledNETStandardPackageVersion)" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Web.Xdt.Extensions\Microsoft.Web.Xdt.Extensions.csproj" />
+    <ProjectReference Include="..\Microsoft.Web.Xdt.Extensions\Microsoft.Web.Xdt.Extensions.csproj"  PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#39 
Microsoft.Web.Xdt.Extensions is a net451 only package that does not want NETStandard.Library. ApplicationInsites needs it removed because they don't publish NETStandard.Library to their feeds.
Microsoft.AspNetCore.AzureAppServices.SiteExtension embeds Microsoft.Web.Xdt.Extensions so it does not need it as a package dependency.