### PR TITLE
Disable net461 for ApplicationInsights test project

### DIFF
--- a/test/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.Tests/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.Tests.csproj
+++ b/test/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.Tests/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.Tests.csproj
@@ -3,8 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The tests in this project fail on Win7 and Win2012-Universe on the CI.
The error:
`System.MissingMethodException : Method not found: 'System.Net.Http.HttpClient Microsoft.AspNetCore.Server.IntegrationTesting.DeploymentResult.CreateHttpClient(System.Net.Http.HttpMessageHandler)'.`
http://aspnetci/viewLog.html?buildId=226589&tab=buildResultsDiv&buildTypeId=XPlat_Windows_Win7_Universe

cc @Tratcher 
@pakrym is investigating. @ryanbrandenburg this should unblock the build if the actual fix is elaborate.