### PR TITLE
Retarget Xdt and SiteExtension to net461

### DIFF
--- a/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <title>ASP.NET Core Extensions</title>
     <Description>This extension enables additional functionality for ASP.NET Core on Azure WebSites, such as enabling Azure logging.</Description>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageTags>aspnet;logging;aspnetcore;AzureSiteExtension</PackageTags>
     <PackageType>AzureSiteExtension</PackageType>

--- a/src/Microsoft.Web.Xdt.Extensions/Microsoft.Web.Xdt.Extensions.csproj
+++ b/src/Microsoft.Web.Xdt.Extensions/Microsoft.Web.Xdt.Extensions.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Additional functionality for Xdt transforms.</Description>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>xdt</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
#58 .NET 4.6.2 is available in Azure and ApplicationInsights does not need a specific version.