### PR TITLE
de-exeify HostingStartup to fix downgrade errors

### DIFF
--- a/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.csproj
+++ b/src/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.csproj
@@ -7,7 +7,6 @@
     <Description>ASP.NET Core lightup integration with Application Insights.</Description>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <OutputType>Exe</OutputType>
     <PackageTags>aspnetcore;ApplicationInsights;Analytics;Telemetry;AppInsights</PackageTags>
   </PropertyGroup>
 

--- a/src/Microsoft.AspNetCore.AzureAppServices.HostingStartup/Microsoft.AspNetCore.AzureAppServices.HostingStartup.csproj
+++ b/src/Microsoft.AspNetCore.AzureAppServices.HostingStartup/Microsoft.AspNetCore.AzureAppServices.HostingStartup.csproj
@@ -7,7 +7,6 @@
     <Description>ASP.NET Core lightup integration with Azure AppServices.</Description>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <OutputType>Exe</OutputType>
     <PackageTags>aspnetcore;azure;appservices</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
The `<OutputType>Exe</OutputType>` section was causing a dependency on `Microsoft.NETCore.App` in the resulting nupkg, which caused all kinds of downgrade errors when building apps (since the SDK also adds a reference to that package, based on the SDK version, and the versions can easily conflict). @pakrym believes this is no longer needed since we only used it to generate the deps file, but we do that differently now.

/fyi @Eilon @muratg @DamianEdwards This should be taken in 2.0 RTM, since it causes extraneous dependencies in the user's app, which can come into conflict when they change CLI/SDK versions. The user would not understand why this downgrade is happening or who is referencing the package since they all involve automatically-referenced packages.