### PR TITLE
Choose port automatically

### DIFF
--- a/test/ApplicationInsights.HostingStartup.Tests/LoggingTest.cs
+++ b/test/ApplicationInsights.HostingStartup.Tests/LoggingTest.cs
@@ -100,6 +100,7 @@ namespace ApplicationInsightsJavaScriptSnippetTest
                 var deploymentParameters = new DeploymentParameters(GetApplicationPath(), ServerType.Kestrel,
                     RuntimeFlavor.CoreClr, RuntimeArchitecture.x64)
                 {
+                    ApplicationBaseUriHint = "http://localhost:0",
                     PublishApplicationBeforeDeployment = true,
                     PreservePublishedApplicationForDebugging = PreservePublishedApplicationForDebugging,
                     TargetFramework = "netcoreapp2.0",


### PR DESCRIPTION
This should improve test reliability by preventing tests from trying to all use port 5000.