### PR TITLE
Add RIDs to sample test project to fix standalone publish

### DIFF
--- a/sample/ApplicationInsightsHostingStartupSample/ApplicationInsightsHostingStartupSample.csproj
+++ b/sample/ApplicationInsightsHostingStartupSample/ApplicationInsightsHostingStartupSample.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <RuntimeIdentifiers>win7-x86;win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We recently disabled publish restore by default and rely on the original repo restore. Apps that use to test publishing standalone need RIDs to get the correct dependencies restored the first time. We do the same for MusicStore.