### PR TITLE
Add AspNetCore runtime site extension

### DIFF
--- a/AzureIntegration.sln
+++ b/AzureIntegration.sln
@@ -1,6 +1,6 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2002
+VisualStudioVersion = 15.0.27016.1
 MinimumVisualStudioVersion = 15.0.26730.03
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.AzureAppServicesIntegration", "src\Microsoft.AspNetCore.AzureAppServicesIntegration\Microsoft.AspNetCore.AzureAppServicesIntegration.csproj", "{5916BEB5-0969-469B-976C-A392E015DFAC}"
 EndProject
@@ -11,9 +11,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FF9B744E-6C5
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2FFE2B87-BF8A-4B38-ADAB-2FE2F9BC4A7C}"
 	ProjectSection(SolutionItems) = preProject
+		build\dependencies.props = build\dependencies.props
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
-		build\dependencies.props = build\dependencies.props
 		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
@@ -46,13 +46,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.AzureA
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.AzureAppServices.TestBundle", "src\Microsoft.AspNetCore.AzureAppServices.TestBundle\Microsoft.AspNetCore.AzureAppServices.TestBundle.csproj", "{1EC31DA1-131D-4257-B001-BE8391E6077E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Web.Xdt.Extensions.Tests", "test\Microsoft.Web.Xdt.Extensions.Tests\Microsoft.Web.Xdt.Extensions.Tests.csproj", "{809AEE05-1B28-4E31-8959-776B249BD725}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Web.Xdt.Extensions.Tests", "test\Microsoft.Web.Xdt.Extensions.Tests\Microsoft.Web.Xdt.Extensions.Tests.csproj", "{809AEE05-1B28-4E31-8959-776B249BD725}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests", "test\Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests\Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests.csproj", "{491A857A-3529-4375-985D-D748F9F01476}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests", "test\Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests\Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests.csproj", "{491A857A-3529-4375-985D-D748F9F01476}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.ApplicationModelDetection", "src\Microsoft.Extensions.ApplicationModelDetection\Microsoft.Extensions.ApplicationModelDetection.csproj", "{F0CABFE8-A5B1-487B-A451-A486D26742D3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.ApplicationModelDetection.Tests", "test\Microsoft.Extensions.ApplicationModelDetection.Tests\Microsoft.Extensions.ApplicationModelDetection.Tests.csproj", "{15664836-2B94-4D2D-AC18-6DED01FCCCBD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Runtime.SiteExtension", "src\Microsoft.AspNetCore.Runtime.SiteExtension\Microsoft.AspNetCore.Runtime.SiteExtension.csproj", "{E1E9BC7A-6951-4B60-8DFB-DBB9AC3CDEB0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -124,6 +126,10 @@ Global
 		{15664836-2B94-4D2D-AC18-6DED01FCCCBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{15664836-2B94-4D2D-AC18-6DED01FCCCBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{15664836-2B94-4D2D-AC18-6DED01FCCCBD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1E9BC7A-6951-4B60-8DFB-DBB9AC3CDEB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1E9BC7A-6951-4B60-8DFB-DBB9AC3CDEB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1E9BC7A-6951-4B60-8DFB-DBB9AC3CDEB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1E9BC7A-6951-4B60-8DFB-DBB9AC3CDEB0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -145,6 +151,7 @@ Global
 		{491A857A-3529-4375-985D-D748F9F01476} = {CD650B4B-81C2-4A44-AEF2-A251A877C1F0}
 		{F0CABFE8-A5B1-487B-A451-A486D26742D3} = {FF9B744E-6C59-40CC-9E41-9D2EBD292435}
 		{15664836-2B94-4D2D-AC18-6DED01FCCCBD} = {CD650B4B-81C2-4A44-AEF2-A251A877C1F0}
+		{E1E9BC7A-6951-4B60-8DFB-DBB9AC3CDEB0} = {FF9B744E-6C59-40CC-9E41-9D2EBD292435}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5743DFE7-1AA5-439D-84AE-A480EA389927}

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15576</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftApplicationInsightsAspNetCorePackageVersion>2.1.1</MicrosoftApplicationInsightsAspNetCorePackageVersion>
-     <MicrosoftAspNetCoreAspNetCoreModulePackageVersion>1.0.0-pre-10202</MicrosoftAspNetCoreAspNetCoreModulePackageVersion>
+     <MicrosoftAspNetCoreAspNetCoreModulePackageVersion>1.0.0-pre-10223</MicrosoftAspNetCoreAspNetCoreModulePackageVersion>
     <MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>
     <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
     <MicrosoftAspNetCoreHostingPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHostingPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,10 +1,11 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15576</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftApplicationInsightsAspNetCorePackageVersion>2.1.1</MicrosoftApplicationInsightsAspNetCorePackageVersion>
+     <MicrosoftAspNetCoreAspNetCoreModulePackageVersion>1.0.0-pre-10196</MicrosoftAspNetCoreAspNetCoreModulePackageVersion>
     <MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>
     <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
     <MicrosoftAspNetCoreHostingPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHostingPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15576</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftApplicationInsightsAspNetCorePackageVersion>2.1.1</MicrosoftApplicationInsightsAspNetCorePackageVersion>
-     <MicrosoftAspNetCoreAspNetCoreModulePackageVersion>1.0.0-pre-10196</MicrosoftAspNetCoreAspNetCoreModulePackageVersion>
+     <MicrosoftAspNetCoreAspNetCoreModulePackageVersion>1.0.0-pre-10202</MicrosoftAspNetCoreAspNetCoreModulePackageVersion>
     <MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>
     <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
     <MicrosoftAspNetCoreHostingPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHostingPackageVersion>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -4,12 +4,21 @@
       <TestDotNetPath>$(RepositoryRoot).test-dotnet\</TestDotNetPath>
       <AppsArtifactDirectory>$(RepositoryRoot)artifacts\apps</AppsArtifactDirectory>
       <SiteExtensionWorkingDirectory>$(TestDotNetPath)extension\</SiteExtensionWorkingDirectory>
-      <SiteExtensionProjectDirectory>$(RepositoryRoot)src\Microsoft.AspNetCore.AzureAppServices.TestBundle\</SiteExtensionProjectDirectory>
+      <SiteExtensionOutputDirectory>$(RepositoryRoot)artifacts\extensions</SiteExtensionOutputDirectory>
       <TestProjectDirectory>$(RepositoryRoot)\test\Microsoft.AspNetCore.AzureAppServices.FunctionalTests\</TestProjectDirectory>
       <SiteExtensionFeed Condition="$(SiteExtensionFeed) == ''">https://dotnet.myget.org/F/aspnetcore-ci-dev/</SiteExtensionFeed>
       <DotnetChannel>master</DotnetChannel>
       <DotnetVersion>coherent</DotnetVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <SiteExtensions Include="AspNetCoreTestBundle">
+      <Project>$(RepositoryRoot)src\Microsoft.AspNetCore.AzureAppServices.TestBundle\Microsoft.AspNetCore.AzureAppServices.TestBundle.csproj</Project>
+    </SiteExtensions>
+    <SiteExtensions Include="AspNetCoreRuntime">
+      <Project>$(RepositoryRoot)src\Microsoft.AspNetCore.Runtime.SiteExtension\Microsoft.AspNetCore.Runtime.SiteExtension.csproj</Project>
+    </SiteExtensions>
+  </ItemGroup>
 
   <Target Name="_AddTestRuntimes">
     <ItemGroup>
@@ -25,10 +34,6 @@
   </Target>
 
   <Target Name="BuildSiteExtension" DependsOnTargets="_AddSiteExtensionRuntimes;InstallDotNet">
-
-    <PropertyGroup>
-      <CliVersionRelativePath>build\dotnet.version</CliVersionRelativePath>
-    </PropertyGroup>
     <ItemGroup>
       <RuntimeArchiveItems Include="$(RuntimeArchives)" />
       <DotNetCacheArchiveItems Include="$(DotNetCacheArchives)" />
@@ -37,15 +42,15 @@
     <UnzipArchive File="%(RuntimeArchiveItems.Identity)" Destination="$(SiteExtensionWorkingDirectory)" Condition="'$(RuntimeArchives)' != ''" Overwrite="true" />
     <UnzipArchive File="%(DotNetCacheArchiveItems.Identity)" Destination="$(SiteExtensionWorkingDirectory)DotNetCache" Condition="'$(DotNetCacheArchives)' != ''" Overwrite="true" />
 
-    <MSBuild Projects="$(SiteExtensionProjectDirectory)Microsoft.AspNetCore.AzureAppServices.TestBundle.csproj"
+    <MSBuild Projects="%(SiteExtensions.Project)"
       Targets="Restore;Pack"
-      Properties="DotnetHomeDirectory=$(SiteExtensionWorkingDirectory);BuildNumber=$(BuildNumber)" />
+      Properties="DotnetHomeDirectory=$(SiteExtensionWorkingDirectory);BuildNumber=$(BuildNumber);PackageOutputPath=$(SiteExtensionOutputDirectory)" />
 
   </Target>
 
   <Target Name="PushSiteExtension">
     <ItemGroup>
-      <RepositoryNupkgs Include="$(SiteExtensionProjectDirectory)bin\$(Configuration)\*.nupkg" />
+      <RepositoryNupkgs Include="$(SiteExtensionOutputDirectory)\%(SiteExtensions.Identity).*.nupkg" />
     </ItemGroup>
 
     <PushNuGetPackages
@@ -69,12 +74,13 @@
 
   </Target>
 
-  <!--
-   git deploy creates read-only files which msbuild is unable to remove
-   NOTE: we run tests only on windows
-   -->
   <Target Name="CleanArtifactsApplications" BeforeTargets="CleanArtifacts" >
+    <!--
+      git deploy creates read-only files which msbuild is unable to remove
+      NOTE: we run tests only on windows
+    -->
     <Exec Command="rmdir /S /Q &quot;$(AppsArtifactDirectory)&quot;" Condition="Exists($(AppsArtifactDirectory))" />
+    <RemoveDir Directories="$(SiteExtensionOutputDirectory)" Condition="Exists($(SiteExtensionOutputDirectory))" />
   </Target>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Runtime.SiteExtension/Microsoft.AspNetCore.Runtime.SiteExtension.csproj
+++ b/src/Microsoft.AspNetCore.Runtime.SiteExtension/Microsoft.AspNetCore.Runtime.SiteExtension.csproj
@@ -22,8 +22,8 @@
     <Content Include="applicationHost.xdt" />
     <Content Include="install.cmd" />
     <Content Include="$(OutputPath)\Microsoft.Web.Xdt.Extensions.dll" PackagePath="content" />
-    <Content Include="$(AspNetCoreModuleX86Location)" PackagePath="content\x86" />
-    <Content Include="$(AspNetCoreModuleX64Location)" PackagePath="content\x64" />
+    <Content Include="$(AspNetCoreModuleX86Location)" PackagePath="content\ancm\x86" />
+    <Content Include="$(AspNetCoreModuleX64Location)" PackagePath="content\ancm\x64" />
 
     <Content Include="$(DotnetHomeDirectory)**\*.*" Condition="$(DotnetHomeDirectory) != ''" PackagePath="content\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>

--- a/src/Microsoft.AspNetCore.Runtime.SiteExtension/Microsoft.AspNetCore.Runtime.SiteExtension.csproj
+++ b/src/Microsoft.AspNetCore.Runtime.SiteExtension/Microsoft.AspNetCore.Runtime.SiteExtension.csproj
@@ -11,7 +11,7 @@
     <IncludeSymbols>false</IncludeSymbols>
     <IncludeSource>false</IncludeSource>
     <ContentTargetFolders>content</ContentTargetFolders>
-    <PackageId>AspNetCoreRuntime</PackageId>
+    <PackageId>Microsoft.AspNetCore.Runtime.SiteExtension</PackageId>
     <!-- These need to be set manually because this is not marked as a shipping (to nuget.org) package. https://github.com/aspnet/AzureIntegration/issues/38 -->
     <PackageLicenseUrl>https://github.com/aspnet/AzureIntegration/blob/rel/2.0.0-preview1/LICENSE.txt</PackageLicenseUrl>
     <PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
@@ -22,11 +22,16 @@
     <Content Include="applicationHost.xdt" />
     <Content Include="install.cmd" />
     <Content Include="$(OutputPath)\Microsoft.Web.Xdt.Extensions.dll" PackagePath="content" />
+    <Content Include="$(AspNetCoreModuleX86Location);$(AspNetCoreModuleX64Location)" PackagePath="content" />
     <Content Include="$(DotnetHomeDirectory)**\*.*" Condition="$(DotnetHomeDirectory) != ''" PackagePath="content\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Web.Xdt.Extensions\Microsoft.Web.Xdt.Extensions.csproj" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.AspNetCoreModule" Version="1.0.0-pre-t000" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Runtime.SiteExtension/Microsoft.AspNetCore.Runtime.SiteExtension.csproj
+++ b/src/Microsoft.AspNetCore.Runtime.SiteExtension/Microsoft.AspNetCore.Runtime.SiteExtension.csproj
@@ -22,7 +22,9 @@
     <Content Include="applicationHost.xdt" />
     <Content Include="install.cmd" />
     <Content Include="$(OutputPath)\Microsoft.Web.Xdt.Extensions.dll" PackagePath="content" />
-    <Content Include="$(AspNetCoreModuleX86Location);$(AspNetCoreModuleX64Location)" PackagePath="content" />
+    <Content Include="$(AspNetCoreModuleX86Location)" PackagePath="content\x86" />
+    <Content Include="$(AspNetCoreModuleX64Location)" PackagePath="content\x64" />
+
     <Content Include="$(DotnetHomeDirectory)**\*.*" Condition="$(DotnetHomeDirectory) != ''" PackagePath="content\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 
@@ -31,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.AspNetCoreModule" Version="1.0.0-pre-t000" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.AspNetCoreModule" Version="$(MicrosoftAspNetCoreAspNetCoreModulePackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Runtime.SiteExtension/Microsoft.AspNetCore.Runtime.SiteExtension.csproj
+++ b/src/Microsoft.AspNetCore.Runtime.SiteExtension/Microsoft.AspNetCore.Runtime.SiteExtension.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>ASP.NET Core Runtime Extensions</Title>
+    <TargetFramework>net461</TargetFramework>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <PackageTags>aspnetcore;AzureSiteExtension</PackageTags>
+    <PackageType>AzureSiteExtension</PackageType>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+    <IncludeSource>false</IncludeSource>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <PackageId>AspNetCoreRuntime</PackageId>
+    <!-- These need to be set manually because this is not marked as a shipping (to nuget.org) package. https://github.com/aspnet/AzureIntegration/issues/38 -->
+    <PackageLicenseUrl>https://github.com/aspnet/AzureIntegration/blob/rel/2.0.0-preview1/LICENSE.txt</PackageLicenseUrl>
+    <PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
+    <PackageProjectUrl>https://www.asp.net/</PackageProjectUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="applicationHost.xdt" />
+    <Content Include="install.cmd" />
+    <Content Include="$(OutputPath)\Microsoft.Web.Xdt.Extensions.dll" PackagePath="content" />
+    <Content Include="$(DotnetHomeDirectory)**\*.*" Condition="$(DotnetHomeDirectory) != ''" PackagePath="content\%(RecursiveDir)%(FileName)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Web.Xdt.Extensions\Microsoft.Web.Xdt.Extensions.csproj" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>
+

--- a/src/Microsoft.AspNetCore.Runtime.SiteExtension/applicationHost.xdt
+++ b/src/Microsoft.AspNetCore.Runtime.SiteExtension/applicationHost.xdt
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+
+  <xdt:Import path="%XDT_EXTENSIONPATH%\Microsoft.Web.Xdt.Extensions.dll"
+              namespace="Microsoft.Web.Xdt.Extensions" />
+
+    <system.webServer xdt:Transform="InsertIfMissing">
+      <runtime xdt:Transform="InsertIfMissing" >
+        <environmentVariables xdt:Transform="InsertIfMissing">
+          <add name="PATH" value="%XDT_EXTENSIONPATH%;%PATH%" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"  />
+        </environmentVariables>
+      </runtime>
+    </system.webServer>
+</configuration>

--- a/src/Microsoft.AspNetCore.Runtime.SiteExtension/install.cmd
+++ b/src/Microsoft.AspNetCore.Runtime.SiteExtension/install.cmd
@@ -1,0 +1,3 @@
+SET DOTNET=D:\Program Files (x86)\dotnet
+
+dotnet msbuild /version

--- a/src/Microsoft.AspNetCore.Runtime.SiteExtension/scmApplicationHost.xdt
+++ b/src/Microsoft.AspNetCore.Runtime.SiteExtension/scmApplicationHost.xdt
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+</configuration>


### PR DESCRIPTION
With latest coherent cli build having 2.0 runtime and aspnetcore ` 2.1.0-preview1-26623` site extension is not very useful at the moment but sets up in required infrastructure for building and publishing.