### PR TITLE
 Build site extensions in main build chain 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ project.lock.json
 global.json
 msbuild.binlog
 .test-dotnet/
+.deps/

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,31 +6,31 @@
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15626</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftApplicationInsightsAspNetCorePackageVersion>2.1.1</MicrosoftApplicationInsightsAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAspNetCoreModulePackageVersion>1.0.0-pre-10223</MicrosoftAspNetCoreAspNetCoreModulePackageVersion>
-    <MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>2.1.0-preview1-27807</MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>
-    <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.1.0-preview1-27807</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHostingPackageVersion>2.1.0-preview1-27807</MicrosoftAspNetCoreHostingPackageVersion>
-    <MicrosoftAspNetCoreIdentityServiceAzureKeyVaultPackageVersion>2.1.0-preview1-27807</MicrosoftAspNetCoreIdentityServiceAzureKeyVaultPackageVersion>
-    <MicrosoftAspNetCoreMvcPackageVersion>2.1.0-preview1-27807</MicrosoftAspNetCoreMvcPackageVersion>
-    <MicrosoftAspNetCoreRazorRuntimePackageVersion>2.1.0-preview1-27807</MicrosoftAspNetCoreRazorRuntimePackageVersion>
-    <MicrosoftAspNetCoreServerIISIntegrationPackageVersion>2.1.0-preview1-27807</MicrosoftAspNetCoreServerIISIntegrationPackageVersion>
-    <MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>0.5.0-preview1-27807</MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelPackageVersion>2.1.0-preview1-27807</MicrosoftAspNetCoreServerKestrelPackageVersion>
-    <MicrosoftAspNetCoreTestHostPackageVersion>2.1.0-preview1-27807</MicrosoftAspNetCoreTestHostPackageVersion>
+    <MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>
+    <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreHostingPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreHostingPackageVersion>
+    <MicrosoftAspNetCoreIdentityServiceAzureKeyVaultPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreIdentityServiceAzureKeyVaultPackageVersion>
+    <MicrosoftAspNetCoreMvcPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreMvcPackageVersion>
+    <MicrosoftAspNetCoreRazorRuntimePackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreRazorRuntimePackageVersion>
+    <MicrosoftAspNetCoreServerIISIntegrationPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreServerIISIntegrationPackageVersion>
+    <MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>0.5.0-preview1-27849</MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>
+    <MicrosoftAspNetCoreServerKestrelPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreServerKestrelPackageVersion>
+    <MicrosoftAspNetCoreTestHostPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftAzureManagementFluentPackageVersion>1.1.3</MicrosoftAzureManagementFluentPackageVersion>
     <MicrosoftAzureServicesAppAuthenticationPackageVersion>1.0.0-preview</MicrosoftAzureServicesAppAuthenticationPackageVersion>
-    <MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>2.1.0-preview1-27807</MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>
-    <MicrosoftExtensionsConfigurationCommandLinePackageVersion>2.1.0-preview1-27807</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.0-preview1-27807</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
-    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.1.0-preview1-27807</MicrosoftExtensionsConfigurationJsonPackageVersion>
-    <MicrosoftExtensionsDiagnosticAdapterPackageVersion>2.1.0-preview1-27807</MicrosoftExtensionsDiagnosticAdapterPackageVersion>
-    <MicrosoftExtensionsLoggingAzureAppServicesPackageVersion>2.1.0-preview1-27807</MicrosoftExtensionsLoggingAzureAppServicesPackageVersion>
-    <MicrosoftExtensionsLoggingConfigurationPackageVersion>2.1.0-preview1-27807</MicrosoftExtensionsLoggingConfigurationPackageVersion>
-    <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.0-preview1-27807</MicrosoftExtensionsLoggingConsolePackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>2.1.0-preview1-27807</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.0-preview1-27807</MicrosoftExtensionsLoggingTestingPackageVersion>
-    <MicrosoftExtensionsProcessSourcesPackageVersion>2.1.0-preview1-27807</MicrosoftExtensionsProcessSourcesPackageVersion>
+    <MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>
+    <MicrosoftExtensionsConfigurationCommandLinePackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsDiagnosticAdapterPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsDiagnosticAdapterPackageVersion>
+    <MicrosoftExtensionsLoggingAzureAppServicesPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsLoggingAzureAppServicesPackageVersion>
+    <MicrosoftExtensionsLoggingConfigurationPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsLoggingConfigurationPackageVersion>
+    <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsLoggingConsolePackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsLoggingTestingPackageVersion>
+    <MicrosoftExtensionsProcessSourcesPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsProcessSourcesPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview1-26008-01</MicrosoftNETCoreApp21PackageVersion>
+    <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview1-26016-05</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftWebXdtPackageVersion>1.4.0</MicrosoftWebXdtPackageVersion>
     <MoqPackageVersion>4.7.49</MoqPackageVersion>

--- a/build/repo.props
+++ b/build/repo.props
@@ -8,8 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ExcludeFromPack Include="$(RepositoryRoot)src\Microsoft.AspNetCore.AzureAppServices.TestBundle\Microsoft.AspNetCore.AzureAppServices.TestBundle.csproj" />
-    <ExcludeFromPack Include="$(RepositoryRoot)src\Microsoft.AspNetCore.Runtime.SiteExtension\Microsoft.AspNetCore.Runtime.SiteExtension.csproj" />
+    <SiteExtensions Include="$(RepositoryRoot)src\Microsoft.AspNetCore.AzureAppServices.TestBundle\Microsoft.AspNetCore.AzureAppServices.TestBundle.csproj" PackageName="AspNetCoreTestBundle" />
+    <SiteExtensions Include="$(RepositoryRoot)src\Microsoft.AspNetCore.Runtime.SiteExtension\Microsoft.AspNetCore.Runtime.SiteExtension.csproj" PackageName="AspNetCoreRuntime" />
+
+    <ExcludeFromPack Include="%(SiteExtensions.Identity)" />
 
     <ExcludeFromTest
       Condition="'$(AntaresTests)' != ''"

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -28,32 +28,51 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_CleanSiteExtension">
+    <RemoveDir Directories="$(SiteExtensionWorkingDirectory)" Condition="Exists($(SiteExtensionWorkingDirectory))" />
+  </Target>
+
   <Target Name="_AddSiteExtensionRuntime">
+    <PropertyGroup>
+      <_SdkVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('$(MSBuildExtensionsPath)'))))</_SdkVersion>
+    </PropertyGroup>
+
     <ItemGroup>
+      <DotNetCoreSdk Include="$(_SdkVersion)" InstallDir="$(SiteExtensionWorkingDirectory)" Arch="x86" />
       <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp21PackageVersion)" InstallDir="$(SiteExtensionWorkingDirectory)" Arch="x86" />
     </ItemGroup>
   </Target>
 
-  <Target Name="BuildSiteExtension" DependsOnTargets="_AddSiteExtensionRuntime;InstallDotNet">
+  <Target Name="BuildSiteExtension" DependsOnTargets="_CleanSiteExtension;_AddSiteExtensionRuntime;InstallDotNet">
     <PropertyGroup>
       <ArtifactDependencyLocation>$(RepositoryRoot)\.deps</ArtifactDependencyLocation>
-      <_SdkVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('$(MSBuildExtensionsPath)'))))</_SdkVersion>
     </PropertyGroup>
 
     <ItemGroup>
       <RuntimeArchiveItems Include="$(RuntimeArchives)" />
       <DotNetCacheArchiveItems Include="$(DotNetCacheArchives)" />
-      <_SdkFiles Include="$(MSBuildExtensionsPath)\**\*" />
+
+      <_CleanupFiles
+        Include="$(SiteExtensionWorkingDirectory)\additionalDeps;$(SiteExtensionWorkingDirectory)\store" />
+
+      <_CleanupFiles
+        Include="$([System.IO.Directory]::GetDirectories('$(SiteExtensionWorkingDirectory)shared\Microsoft.NETCore.App\'))"
+        Exclude="$(SiteExtensionWorkingDirectory)shared\Microsoft.NETCore.App\$(MicrosoftNETCoreApp21PackageVersion)" />
+
+      <_CleanupFiles
+        Include="$([System.IO.Directory]::GetDirectories('$(SiteExtensionWorkingDirectory)host\fxr'))"
+        Exclude="$(SiteExtensionWorkingDirectory)host\fxr\$(MicrosoftNETCoreApp21PackageVersion)" />
 
       <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(PackageVersion)" />
       <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="$(PackageVersion)" />
       <BundledTemplate Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="$(PackageVersion)" />
     </ItemGroup>
 
-    <RemoveDir Directories="$(SiteExtensionWorkingDirectory)" Condition="Exists($(SiteExtSiteExtensionWorkingDirectoryensionOutputDirectory))" />
+    <Message Text="Removing %(_CleanupFiles.Identity)" Importance="High" />
+    <RemoveDir Directories="@(_CleanupFiles)" />
 
-    <Copy SourceFiles="@(_SdkFiles)" DestinationFolder="$(SiteExtensionWorkingDirectory)\sdk\$(_SdkVersion)\%(RecursiveDir)" />
     <Copy SourceFiles="$(ArtifactDependencyLocation)\%(BundledTemplate.Identity).%(Version).nupkg" DestinationFolder="$(SiteExtensionWorkingDirectory)\sdk\$(_SdkVersion)\Templates" />
+    <Copy SourceFiles="$(ArtifactDependencyLocation)\nuGetPackagesArchive-$(PackageVersion).lzma" DestinationFiles="$(SiteExtensionWorkingDirectory)\sdk\$(_SdkVersion)\nuGetPackagesArchive.lzma" />
 
     <UnzipArchive File="$(ArtifactDependencyLocation)\aspnetcore-shared-$(PackageVersion)-win7-x86.zip" Destination="$(SiteExtensionWorkingDirectory)" Overwrite="true" />
     <UnzipArchive File="%(RuntimeArchiveItems.Identity)" Destination="$(SiteExtensionWorkingDirectory)" Condition="'$(RuntimeArchives)' != ''" Overwrite="true" />

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -42,10 +42,6 @@
   </Target>
 
   <Target Name="BuildSiteExtension" DependsOnTargets="_CleanSiteExtension;_AddSiteExtensionRuntime;InstallDotNet">
-    <PropertyGroup>
-      <ArtifactDependencyLocation>$(RepositoryRoot)\.deps</ArtifactDependencyLocation>
-    </PropertyGroup>
-
     <ItemGroup>
       <RuntimeArchiveItems Include="$(RuntimeArchives)" />
       <DotNetCacheArchiveItems Include="$(DotNetCacheArchives)" />

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,4 +1,5 @@
 <Project>
+  <Import Project="$(RepositoryRoot)\build\dependencies.props" />
 
   <PropertyGroup>
       <TestDotNetPath>$(RepositoryRoot).test-dotnet\</TestDotNetPath>
@@ -23,22 +24,38 @@
   <Target Name="_AddTestRuntimes">
     <ItemGroup>
       <DotNetCoreSdk Include="2.0.0" InstallDir="$(TestDotNetPath)2.0\" FallbackPackageCache="True" />
-      <DotNetCoreSdk Include="coherent" Channel="master" InstallDir="$(TestDotNetPath)latest\" FallbackPackageCache="True" />
+      <DotNetCoreSdk Include="$(MicrosoftNETCoreApp21PackageVersion)" Channel="master" InstallDir="$(TestDotNetPath)latest\" FallbackPackageCache="True" />
     </ItemGroup>
   </Target>
 
-  <Target Name="_AddSiteExtensionRuntimes">
+  <Target Name="_AddSiteExtensionRuntime">
     <ItemGroup>
-      <DotNetCoreSdk Include="coherent" Channel="master" InstallDir="$(SiteExtensionWorkingDirectory)" Arch="x86" />
+      <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp21PackageVersion)" InstallDir="$(SiteExtensionWorkingDirectory)" Arch="x86" />
     </ItemGroup>
   </Target>
 
-  <Target Name="BuildSiteExtension" DependsOnTargets="_AddSiteExtensionRuntimes;InstallDotNet">
+  <Target Name="BuildSiteExtension" DependsOnTargets="_AddSiteExtensionRuntime;InstallDotNet">
+    <PropertyGroup>
+      <ArtifactDependencyLocation>$(RepositoryRoot)\.deps</ArtifactDependencyLocation>
+      <_SdkVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('$(MSBuildExtensionsPath)'))))</_SdkVersion>
+    </PropertyGroup>
+
     <ItemGroup>
       <RuntimeArchiveItems Include="$(RuntimeArchives)" />
       <DotNetCacheArchiveItems Include="$(DotNetCacheArchives)" />
+      <_SdkFiles Include="$(MSBuildExtensionsPath)\**\*" />
+
+      <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(PackageVersion)" />
+      <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="$(PackageVersion)" />
+      <BundledTemplate Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="$(PackageVersion)" />
     </ItemGroup>
 
+    <RemoveDir Directories="$(SiteExtensionWorkingDirectory)" Condition="Exists($(SiteExtSiteExtensionWorkingDirectoryensionOutputDirectory))" />
+
+    <Copy SourceFiles="@(_SdkFiles)" DestinationFolder="$(SiteExtensionWorkingDirectory)\sdk\$(_SdkVersion)\%(RecursiveDir)" />
+    <Copy SourceFiles="$(ArtifactDependencyLocation)\%(BundledTemplate.Identity).%(Version).nupkg" DestinationFolder="$(SiteExtensionWorkingDirectory)\sdk\$(_SdkVersion)\Templates" />
+
+    <UnzipArchive File="$(ArtifactDependencyLocation)\aspnetcore-shared-$(PackageVersion)-win7-x86.zip" Destination="$(SiteExtensionWorkingDirectory)" Overwrite="true" />
     <UnzipArchive File="%(RuntimeArchiveItems.Identity)" Destination="$(SiteExtensionWorkingDirectory)" Condition="'$(RuntimeArchives)' != ''" Overwrite="true" />
     <UnzipArchive File="%(DotNetCacheArchiveItems.Identity)" Destination="$(SiteExtensionWorkingDirectory)DotNetCache" Condition="'$(DotNetCacheArchives)' != ''" Overwrite="true" />
 

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -84,6 +84,19 @@
 
   </Target>
 
+  <Target Name="PushSiteExtension">
+    <ItemGroup>
+      <RepositoryNupkgs Include="$(SiteExtensionOutputDirectory)\%(SiteExtensions.PackageName).*.nupkg" />
+    </ItemGroup>
+
+    <PushNuGetPackages
+      Packages="@(RepositoryNupkgs)"
+      Feed="$(SiteExtensionFeed)"
+      ApiKey="$(APIKey)"
+      TimeoutSeconds="600"/>
+
+  </Target>
+
   <Target Name="TestSiteExtension" DependsOnTargets="_AddTestRuntimes;InstallDotNet;Restore">
 
     <Copy SourceFiles="$(TestProjectDirectory)NuGet.config.template" DestinationFiles="$(RepositoryRoot)artifacts\NuGet.config" />

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -6,21 +6,12 @@
       <TestDotNetPath>$(RepositoryRoot).test-dotnet\</TestDotNetPath>
       <AppsArtifactDirectory>$(RepositoryRoot)artifacts\apps</AppsArtifactDirectory>
       <SiteExtensionWorkingDirectory>$(TestDotNetPath)extension\</SiteExtensionWorkingDirectory>
-      <SiteExtensionOutputDirectory>$(RepositoryRoot)artifacts\extensions</SiteExtensionOutputDirectory>
+      <SiteExtensionOutputDirectory>$(RepositoryRoot)artifacts\build</SiteExtensionOutputDirectory>
       <TestProjectDirectory>$(RepositoryRoot)\test\Microsoft.AspNetCore.AzureAppServices.FunctionalTests\</TestProjectDirectory>
       <SiteExtensionFeed Condition="$(SiteExtensionFeed) == ''">https://dotnet.myget.org/F/aspnetcore-ci-dev/</SiteExtensionFeed>
       <DotnetChannel>master</DotnetChannel>
       <DotnetVersion>coherent</DotnetVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <SiteExtensions Include="AspNetCoreTestBundle">
-      <Project>$(RepositoryRoot)src\Microsoft.AspNetCore.AzureAppServices.TestBundle\Microsoft.AspNetCore.AzureAppServices.TestBundle.csproj</Project>
-    </SiteExtensions>
-    <SiteExtensions Include="AspNetCoreRuntime">
-      <Project>$(RepositoryRoot)src\Microsoft.AspNetCore.Runtime.SiteExtension\Microsoft.AspNetCore.Runtime.SiteExtension.csproj</Project>
-    </SiteExtensions>
-  </ItemGroup>
 
   <Target Name="_AddTestRuntimes">
     <ItemGroup>
@@ -37,7 +28,12 @@
 
     <ItemGroup>
       <DotNetCoreSdk Include="$(_SdkVersion)" InstallDir="$(SiteExtensionWorkingDirectory)" Arch="x86" />
-      <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp21PackageVersion)" InstallDir="$(SiteExtensionWorkingDirectory)" Arch="x86" />
+      <DotNetCoreRuntime
+        Include="$(MicrosoftNETCoreApp21PackageVersion)"
+        InstallDir="$(SiteExtensionWorkingDirectory)"
+        Arch="x86"
+        Feed="$(DotNetAssetRootUrl)"
+        FeedCredential="$(DotNetAssetRootAccessTokenSuffix)" />
     </ItemGroup>
   </Target>
 

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -53,7 +53,7 @@
       <DotNetCacheArchiveItems Include="$(DotNetCacheArchives)" />
 
       <_CleanupFiles
-        Include="$(SiteExtensionWorkingDirectory)\additionalDeps;$(SiteExtensionWorkingDirectory)\store" />
+        Include="$(SiteExtensionWorkingDirectory)additionalDeps;$(SiteExtensionWorkingDirectory)store" />
 
       <_CleanupFiles
         Include="$([System.IO.Directory]::GetDirectories('$(SiteExtensionWorkingDirectory)shared\Microsoft.NETCore.App\'))"
@@ -78,22 +78,9 @@
     <UnzipArchive File="%(RuntimeArchiveItems.Identity)" Destination="$(SiteExtensionWorkingDirectory)" Condition="'$(RuntimeArchives)' != ''" Overwrite="true" />
     <UnzipArchive File="%(DotNetCacheArchiveItems.Identity)" Destination="$(SiteExtensionWorkingDirectory)DotNetCache" Condition="'$(DotNetCacheArchives)' != ''" Overwrite="true" />
 
-    <MSBuild Projects="%(SiteExtensions.Project)"
+    <MSBuild Projects="%(SiteExtensions.Idenity)"
       Targets="Restore;Pack"
       Properties="DotnetHomeDirectory=$(SiteExtensionWorkingDirectory);BuildNumber=$(BuildNumber);PackageOutputPath=$(SiteExtensionOutputDirectory)" />
-
-  </Target>
-
-  <Target Name="PushSiteExtension">
-    <ItemGroup>
-      <RepositoryNupkgs Include="$(SiteExtensionOutputDirectory)\%(SiteExtensions.Identity).*.nupkg" />
-    </ItemGroup>
-
-    <PushNuGetPackages
-      Packages="@(RepositoryNupkgs)"
-      Feed="$(SiteExtensionFeed)"
-      ApiKey="$(APIKey)"
-      TimeoutSeconds="600"/>
 
   </Target>
 

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -2,6 +2,7 @@
   <Import Project="$(RepositoryRoot)\build\dependencies.props" />
 
   <PropertyGroup>
+      <_SdkVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('$(MSBuildExtensionsPath)'))))</_SdkVersion>
       <TestDotNetPath>$(RepositoryRoot).test-dotnet\</TestDotNetPath>
       <AppsArtifactDirectory>$(RepositoryRoot)artifacts\apps</AppsArtifactDirectory>
       <SiteExtensionWorkingDirectory>$(TestDotNetPath)extension\</SiteExtensionWorkingDirectory>
@@ -24,7 +25,7 @@
   <Target Name="_AddTestRuntimes">
     <ItemGroup>
       <DotNetCoreSdk Include="2.0.0" InstallDir="$(TestDotNetPath)2.0\" FallbackPackageCache="True" />
-      <DotNetCoreSdk Include="$(MicrosoftNETCoreApp21PackageVersion)" Channel="master" InstallDir="$(TestDotNetPath)latest\" FallbackPackageCache="True" />
+      <DotNetCoreSdk Include="$(_SdkVersion)" InstallDir="$(TestDotNetPath)latest\" FallbackPackageCache="True" />
     </ItemGroup>
   </Target>
 
@@ -33,9 +34,6 @@
   </Target>
 
   <Target Name="_AddSiteExtensionRuntime">
-    <PropertyGroup>
-      <_SdkVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('$(MSBuildExtensionsPath)'))))</_SdkVersion>
-    </PropertyGroup>
 
     <ItemGroup>
       <DotNetCoreSdk Include="$(_SdkVersion)" InstallDir="$(SiteExtensionWorkingDirectory)" Arch="x86" />
@@ -78,7 +76,7 @@
     <UnzipArchive File="%(RuntimeArchiveItems.Identity)" Destination="$(SiteExtensionWorkingDirectory)" Condition="'$(RuntimeArchives)' != ''" Overwrite="true" />
     <UnzipArchive File="%(DotNetCacheArchiveItems.Identity)" Destination="$(SiteExtensionWorkingDirectory)DotNetCache" Condition="'$(DotNetCacheArchives)' != ''" Overwrite="true" />
 
-    <MSBuild Projects="%(SiteExtensions.Idenity)"
+    <MSBuild Projects="%(SiteExtensions.Identity)"
       Targets="Restore;Pack"
       Properties="DotnetHomeDirectory=$(SiteExtensionWorkingDirectory);BuildNumber=$(BuildNumber);PackageOutputPath=$(SiteExtensionOutputDirectory)" />
 

--- a/src/Microsoft.AspNetCore.AzureAppServices.TestBundle/Microsoft.AspNetCore.AzureAppServices.TestBundle.csproj
+++ b/src/Microsoft.AspNetCore.AzureAppServices.TestBundle/Microsoft.AspNetCore.AzureAppServices.TestBundle.csproj
@@ -30,10 +30,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Web.Xdt.Extensions\Microsoft.Web.Xdt.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
-
-  <Target Name="ReportPackageVersion" BeforeTargets="Pack">
-    <Message Text="##teamcity[setParameter name='SiteExtensionPackageName' value='$(PackageId)']" Importance="high" />
-    <Message Text="##teamcity[setParameter name='SiteExtensionPackageVersion' value='$(PackageVersion)']" Importance="high" />
-  </Target>
 </Project>
 


### PR DESCRIPTION
1. Detect SDK we are running and use it for site extension
1. Delete runtime and host that SDK brings
1. Use `dependencies.props` to get shared runtime version
1. Drop in AspNetCore shared runtime
1. Drop in latest templates
