### PR TITLE
Fix misnamed variables

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,8 +7,8 @@
     <InternalAspNetCoreSiteExtensionSdkPackageVersion>2.1.0-preview1-15671</InternalAspNetCoreSiteExtensionSdkPackageVersion>
     <MicrosoftApplicationInsightsAspNetCorePackageVersion>2.1.1</MicrosoftApplicationInsightsAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAspNetCoreModulePackageVersion>2.1.0-preview1-28153</MicrosoftAspNetCoreAspNetCoreModulePackageVersion>
-    <MicrosoftAspNetCoreAzureAppServicesHostingStartupVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreAzureAppServicesHostingStartupVersion>
-    <MicrosoftAspNetCoreAzureKeyVaultHostingStartupVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreAzureKeyVaultHostingStartupVersion>
+    <MicrosoftAspNetCoreAzureAppServicesHostingStartupPackageVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreAzureAppServicesHostingStartupPackageVersion>
+    <MicrosoftAspNetCoreAzureKeyVaultHostingStartupPackageVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreAzureKeyVaultHostingStartupPackageVersion>
     <MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>2.1.0-preview1-28153</MicrosoftAspNetCoreDataProtectionAzureKeyVaultPackageVersion>
     <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.1.0-preview1-28153</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
     <MicrosoftAspNetCoreHostingPackageVersion>2.1.0-preview1-28153</MicrosoftAspNetCoreHostingPackageVersion>

--- a/extensions/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/extensions/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <HostingStartupPackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="$(MicrosoftAspNetCoreAzureAppServicesHostingStartupVersion)" />
-    <HostingStartupPackageReference Include="Microsoft.AspNetCore.AzureKeyVault.HostingStartup" Version="$(MicrosoftAspNetCoreAzureKeyVaultHostingStartupVersion)"  />
+    <HostingStartupPackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="$(MicrosoftAspNetCoreAzureAppServicesHostingStartupPackageVersion)" />
+    <HostingStartupPackageReference Include="Microsoft.AspNetCore.AzureKeyVault.HostingStartup" Version="$(MicrosoftAspNetCoreAzureKeyVaultHostingStartupPackageVersion)"  />
 
     <PackageReference Include="Internal.AspNetCore.SiteExtension.Sdk" Version="$(InternalAspNetCoreSiteExtensionSdkPackageVersion)" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
These properties were misnamed which caused PipeBuild to fail because they weren't being overridden.