### PR TITLE
Enable KeyVault hosting startup

### DIFF
--- a/extensions/Microsoft.AspNetCore.AzureAppServices.SiteExtension/applicationHost.xdt
+++ b/extensions/Microsoft.AspNetCore.AzureAppServices.SiteExtension/applicationHost.xdt
@@ -9,7 +9,7 @@
         <environmentVariables xdt:Transform="InsertIfMissing">
           <add name="DOTNET_ADDITIONAL_DEPS" value="%XDT_EXTENSIONPATH%\additionalDeps\Microsoft.AspNetCore.AzureAppServices.HostingStartup\;%XDT_EXTENSIONPATH%\additionalDeps\Microsoft.AspNetCore.AzureKeyVault.HostingStartup\;%ProgramFiles%\dotnet\additionalDeps\Microsoft.AspNetCore.AzureAppServices.HostingStartup\" xdt:Locator="Match(name)" xdt:Transform="InsertOrAppendAttribute(Attribute='value')" />
           <add name="DOTNET_SHARED_STORE" value="%XDT_EXTENSIONPATH%\store" xdt:Locator="Match(name)" xdt:Transform="InsertOrAppendAttribute(Attribute='value')" />
-          <add name="ASPNETCORE_HOSTINGSTARTUPASSEMBLIES" value="Microsoft.AspNetCore.AzureAppServices.HostingStartup" xdt:Locator="Match(name)" xdt:Transform="InsertOrAppendAttribute(Attribute='value')" />
+          <add name="ASPNETCORE_HOSTINGSTARTUPASSEMBLIES" value="Microsoft.AspNetCore.AzureAppServices.HostingStartup;Microsoft.AspNetCore.AzureKeyVault.HostingStartup" xdt:Locator="Match(name)" xdt:Transform="InsertOrAppendAttribute(Attribute='value')" />
         </environmentVariables>
       </runtime>
     </system.webServer>

--- a/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/TransformTest.cs
+++ b/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/TransformTest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.AzureAppServices.SiteExtension
             var startupAssembliesElement = sharedStoreElement.NextSibling;
             Assert.Equal("add", startupAssembliesElement.Name);
             Assert.Equal("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES", startupAssembliesElement.Attributes["name"].Value);
-            Assert.Equal("Microsoft.AspNetCore.AzureAppServices.HostingStartup", startupAssembliesElement.Attributes["value"].Value);
+            Assert.Equal("Microsoft.AspNetCore.AzureAppServices.HostingStartup;Microsoft.AspNetCore.AzureKeyVault.HostingStartup", startupAssembliesElement.Attributes["value"].Value);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.AzureAppServices.SiteExtension
             var startupAssembliesElement = sharedStoreElement.NextSibling;
             Assert.Equal("add", startupAssembliesElement.Name);
             Assert.Equal("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES", startupAssembliesElement.Attributes["name"].Value);
-            Assert.Equal("ExistingValue2;Microsoft.AspNetCore.AzureAppServices.HostingStartup", startupAssembliesElement.Attributes["value"].Value);
+            Assert.Equal("ExistingValue2;Microsoft.AspNetCore.AzureAppServices.HostingStartup;Microsoft.AspNetCore.AzureKeyVault.HostingStartup", startupAssembliesElement.Attributes["value"].Value);
         }
 
         private static XmlDocument LoadDocAndRunTransform(string docName)


### PR DESCRIPTION
We already ship additional deps and runtime store for keyvault hosting startup.

This change adds keyvault to  `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES`