### PR TITLE
Add KeyVault hosting statup attribute injection

### DIFF
--- a/src/Microsoft.AspNetCore.AzureKeyVault.HostingStartup/Microsoft.AspNetCore.AzureKeyVault.HostingStartup.csproj
+++ b/src/Microsoft.AspNetCore.AzureKeyVault.HostingStartup/Microsoft.AspNetCore.AzureKeyVault.HostingStartup.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="$(MicrosoftAzureServicesAppAuthenticationPackageVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="contentFiles\**\*" Pack="true" PackagePath="contentFiles" BuildAction="Compile" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.AspNetCore.AzureKeyVault.HostingStartup/Microsoft.AspNetCore.AzureKeyVault.HostingStartup.csproj
+++ b/src/Microsoft.AspNetCore.AzureKeyVault.HostingStartup/Microsoft.AspNetCore.AzureKeyVault.HostingStartup.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <Content Include="contentFiles\**\*" Pack="true" PackagePath="contentFiles" BuildAction="Compile" />
+    <Content Include="build\**\*" Pack="true" PackagePath="build" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.AzureKeyVault.HostingStartup/build/Microsoft.AspNetCore.AzureKeyVault.HostingStartup.props
+++ b/src/Microsoft.AspNetCore.AzureKeyVault.HostingStartup/build/Microsoft.AspNetCore.AzureKeyVault.HostingStartup.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <Compile Update="@(Compile)">
+      <Visible Condition="'%(NuGetPackageId)' == 'Microsoft.AspNetCore.AzureKeyVault.HostingStartup'">false</Visible>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.AspNetCore.AzureKeyVault.HostingStartup/contentFiles/cs/netstandard2.0/_AssembyInfo.KeyVaultHostingStartup.cs
+++ b/src/Microsoft.AspNetCore.AzureKeyVault.HostingStartup/contentFiles/cs/netstandard2.0/_AssembyInfo.KeyVaultHostingStartup.cs
@@ -1,0 +1,5 @@
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
+
+[assembly: HostingStartup(typeof(Microsoft.AspNetCore.AzureKeyVault.HostingStartup.AzureKeyVaultHostingStartup))]


### PR DESCRIPTION
https://github.com/aspnet/AzureIntegration/issues/160

We can't use `AssemblyInfo` because our attribute has a non-string parameter.