### PR TITLE
Disable NU5119 for site extensions

### DIFF
--- a/extensions/Directory.Build.props
+++ b/extensions/Directory.Build.props
@@ -9,6 +9,12 @@
     <IncludeSymbols>false</IncludeSymbols>
     <IncludeSource>false</IncludeSource>
     <ContentTargetFolders>content</ContentTargetFolders>
+    <!--
+        NuGet skips files ending .nuget producing warning at the same time
+        there is no way to disable default excludes from MsBuild (see:https://github.com/NuGet/Home/issues/6450)
+        and we don't care about item templates on Antares
+     -->
+    <NoWarn>$(NoWarn);NU5119</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />


### PR DESCRIPTION
NuGet skips files ending .nuget producing warnings at the same time.
There is no way to disable default excludes from MSBuild (see:https://github.com/NuGet/Home/issues/6450) and we don't care about item templates on Antares