### PR TITLE
Remove unnecessary ApplicationBaseUriHint

### DIFF
--- a/test/ApplicationInsights.HostingStartup.Tests/LoggingTest.cs
+++ b/test/ApplicationInsights.HostingStartup.Tests/LoggingTest.cs
@@ -109,7 +109,6 @@ namespace ApplicationInsightsJavaScriptSnippetTest
                 var deploymentParameters = new DeploymentParameters(GetApplicationPath(), ServerType.Kestrel,
                     RuntimeFlavor.CoreClr, RuntimeArchitecture.x64)
                 {
-                    ApplicationBaseUriHint = "http://localhost:0",
                     PublishApplicationBeforeDeployment = true,
                     PreservePublishedApplicationForDebugging = PreservePublishedApplicationForDebugging,
                     TargetFramework = "netcoreapp2.0",


### PR DESCRIPTION
- Allows ApplicationDeployer to directly bind to dynamic port 0, which is more reliable than GetNextPort() which is required when ApplicationBaseUriHint is set.
- Addresses https://github.com/aspnet/AzureIntegration/issues/184