### PR TITLE
Produce a zip containing site-extension files during regular build

### DIFF
--- a/build/PackSiteExtension.targets
+++ b/build/PackSiteExtension.targets
@@ -3,15 +3,25 @@
     <PackageDependsOn>$(PackageDependsOn);PackSiteExtensionFiles</PackageDependsOn>
     <MSBuildProjectFiles>$(MSBuildProjectFiles);$(MSBuildThisFileFullPath)</MSBuildProjectFiles>
 
-    <SiteExtensionOobArchive>$(BuildDir)aspnetcore-site-extension-internal-$(PackageVersion).zip</SiteExtensionOobArchive>
+    <SiteExtensionOobArchive>$(BuildDir)runtime-site-extension-internal-$(PackageVersion).zip</SiteExtensionOobArchive>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ArtifactInfo Include="$(SiteExtensionOobArchive)">
+      <ArtifactType>ZipArchive</ArtifactType>
+      <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
+      <Category>shipoob</Category>
+    </ArtifactInfo>
+    <FilesToSign Include="$(SiteExtensionOobArchive)" IsContainer="true" />
+    <FilesToSign Include="content/Microsoft.Web.Xdt.Extensions.dll" Container="$(SiteExtensionOobArchive)" Certificate="$(AssemblySigningCertName)" />
+  </ItemGroup>
 
   <Target Name="PackSiteExtensionFiles"
     DependsOnTargets="Compile;_CollectSiteExtensionFiles"
     Inputs="@(SiteExtensionFile);$(MSBuildProjectFiles)"
     Outputs="$(SiteExtensionOobArchive)">
 
-    <ZipArchive 
+    <ZipArchive
       SourceFiles="@(SiteExtensionFile)"
       WorkingDirectory="$(SiteExtBasePath)"
       File="$(SiteExtensionOobArchive)"

--- a/build/PackSiteExtension.targets
+++ b/build/PackSiteExtension.targets
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <PackageDependsOn>$(PackageDependsOn);PackSiteExtensionFiles</PackageDependsOn>
+    <MSBuildProjectFiles>$(MSBuildProjectFiles);$(MSBuildThisFileFullPath)</MSBuildProjectFiles>
+
+    <SiteExtensionOobArchive>$(BuildDir)aspnetcore-site-extension-internal-$(PackageVersion).zip</SiteExtensionOobArchive>
+  </PropertyGroup>
+
+  <Target Name="PackSiteExtensionFiles"
+    DependsOnTargets="Compile;_CollectSiteExtensionFiles"
+    Inputs="@(SiteExtensionFile);$(MSBuildProjectFiles)"
+    Outputs="$(SiteExtensionOobArchive)">
+
+    <ZipArchive 
+      SourceFiles="@(SiteExtensionFile)"
+      WorkingDirectory="$(SiteExtBasePath)"
+      File="$(SiteExtensionOobArchive)"
+      Overwrite="True" />
+
+  </Target>
+
+  <Target Name="_CollectSiteExtensionFiles">
+    <PropertyGroup>
+      <SiteExtBasePath>$(RepositoryRoot)extensions\Microsoft.AspNetCore.Runtime.SiteExtension\</SiteExtBasePath>
+    </PropertyGroup>
+    <ItemGroup>
+      <SiteExtensionFile Include="$(RepositoryRoot)src\Microsoft.Web.Xdt.Extensions\bin\$(Configuration)\net461\Microsoft.Web.Xdt.Extensions.dll"
+        Link="content/Microsoft.Web.Xdt.Extensions.dll" />
+      <SiteExtensionFile Include="$(SiteExtBasePath)install.cmd"
+        Link="content/install.cmd" />
+      <SiteExtensionFile Include="$(SiteExtBasePath)applicationHost.xdt"
+        Link="content/applicationHost.xdt" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/build/repo.props
+++ b/build/repo.props
@@ -1,5 +1,9 @@
 <Project>
+  <Import Project="dependencies.props" />
+
   <PropertyGroup>
+    <AssemblySigningCertName>Microsoft</AssemblySigningCertName>
+
     <FunctionalTestsProject>$(RepositoryRoot)test\Microsoft.AspNetCore.AzureAppServices.FunctionalTests\Microsoft.AspNetCore.AzureAppServices.FunctionalTests.csproj</FunctionalTestsProject>
 
     <!-- These properties are use by the automation that updates dependencies.props -->

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,5 +1,6 @@
 <Project>
   <Import Project="$(RepositoryRoot)\build\dependencies.props" />
+  <Import Project="PackSiteExtension.targets" />
 
   <PropertyGroup>
       <ComposeSdk Condition="$(SITE_EXTENSION_SDK_VERSION) == ''">True</ComposeSdk>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,5 +1,4 @@
 <Project>
-  <Import Project="$(RepositoryRoot)\build\dependencies.props" />
   <Import Project="PackSiteExtension.targets" />
 
   <PropertyGroup>


### PR DESCRIPTION
Produces a small zip of the binaries we produce that go into the side extension. Produce this during a normal build so it can be signed and uploaded to prodcon.