### PR TITLE
Do not reference AspNetCoreModuleV2 on non-windows

### DIFF
--- a/extensions/Microsoft.AspNetCore.Runtime.SiteExtension/Microsoft.AspNetCore.Runtime.SiteExtension.csproj
+++ b/extensions/Microsoft.AspNetCore.Runtime.SiteExtension/Microsoft.AspNetCore.Runtime.SiteExtension.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Web.Xdt.Extensions\Microsoft.Web.Xdt.Extensions.csproj" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.AspNetCoreModuleV2" Version="$(MicrosoftAspNetCoreAspNetCoreModuleV2PackageVersion)" />
+    <PackageReference Condition="'$(OS)' == 'Windows_NT'" Include="Microsoft.AspNetCore.AspNetCoreModuleV2" Version="$(MicrosoftAspNetCoreAspNetCoreModuleV2PackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We don't build site extension on non-windows but restore fails because `Microsoft.AspNetCore.AspNetCoreModuleV2` is not produced on non-windows platforms.

/cc @Eilon 