### PR TITLE
Add AspNetCore runtime back into the runtime site extension

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -39,6 +39,7 @@
   </Target>
 
   <Target Name="PrepareSiteExtensionSdk" DependsOnTargets="_AddSiteExtensionRuntime;InstallDotNet">
+    <UnzipArchive File="$(ArtifactDependencyLocation)\aspnetcore-runtime-internal-$(PackageVersion)-win-$(SiteExtensionArch).zip" Destination="$(SiteExtensionWorkingDirectory)" Overwrite="true" />
   </Target>
 
   <Target Name="PrepareSiteExtensionSdks">


### PR DESCRIPTION
Fixes:https://github.com/aspnet/AzureIntegration/issues/243

I got overzealous in cleaning up site extension build an removed the line that unpacked AspNetCore runtime.